### PR TITLE
added specific versions for upython2 and upython3 (used in the ingestor)

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -1,14 +1,4 @@
 {
-    "shotgundesktop": {
-        "version": "fc20",
-        "addons": {
-            "ingestor": {
-                "options": {
-                    "enabled": true
-                }
-            }
-        }
-    },
     "firefox": "59.0.1",
     "slack": "3.0.5",
     "cmake": "3.9.1",

--- a/src/apps.json
+++ b/src/apps.json
@@ -63,6 +63,8 @@
             }
         }
     },
+    "upython2": "2.7.13",
+    "upython3": "3.6.2",
     "deadlinelauncher": "9.0.3.0",
     "deadlinecommand": "9.0.3.0",
     "deadlinemonitor": "9.0.3.0",


### PR DESCRIPTION
This pull request adds upython2 and upython3 which is a way to tell which python version should be used when those major python versions are request (used by the new task wrappers introduced by https://github.com/umediayvr/ingestor/pull/123).

# Change Log
- Added versions for upython2 and upython3