### PR TITLE
keeping only a single version for deadline

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -55,10 +55,7 @@
     },
     "upython2": "2.7.13",
     "upython3": "3.6.2",
-    "deadlinelauncher": "9.0.3.0",
-    "deadlinecommand": "9.0.3.0",
-    "deadlinemonitor": "9.0.3.0",
-    "deadlineslave": "9.0.3.0",
+    "deadline": "9.0.3.0",
     "rv": {
         "version": "7.2.0",
         "addons": {


### PR DESCRIPTION
This pull request is related with the changes on ulauncher about adding support for custom executables (https://github.com/umediayvr/ulauncher/pull/70).

# Change Log
- using a single version for deadline